### PR TITLE
Fixed linter with resourceGroup().location parameter

### DIFF
--- a/Bicep/Compute/WindowsVirtualMachine.bicep
+++ b/Bicep/Compute/WindowsVirtualMachine.bicep
@@ -4,7 +4,7 @@ targetScope = 'resourceGroup'
 @description('the name of the reosurce')
 param name string
 @description('The location - uses the resource group location by default')
-param location string = ''
+param location string = resourceGroup().location
 @description('The tags')
 param tags object = {}
 @allowed([
@@ -219,7 +219,7 @@ param bootDiagnosticsstorageAccountName string
 
 resource windowsVM 'Microsoft.Compute/virtualMachines@2020-12-01' = {
   name: name
-  location: !empty(location) ? location : resourceGroup().location
+  location: location
   tags: tags
   properties: {
     hardwareProfile: {

--- a/Bicep/Compute/WindowsVirtualMachineWithDataDisks.bicep
+++ b/Bicep/Compute/WindowsVirtualMachineWithDataDisks.bicep
@@ -4,7 +4,7 @@ targetScope = 'resourceGroup'
 @description('the name of the reosurce')
 param name string
 @description('The location - uses the resource group location by default')
-param location string = ''
+param location string = resourceGroup().location
 @description('The tags')
 param tags object = {}
 @allowed([
@@ -228,7 +228,7 @@ param DataDisksSizeGb int = 100
 
 resource windowsVM 'Microsoft.Compute/virtualMachines@2020-12-01' = {
   name: name
-  location: !empty(location) ? location : resourceGroup().location
+  location: location
   tags: tags
   properties: {
     hardwareProfile: {

--- a/Bicep/KeyVault/KeyVault.bicep
+++ b/Bicep/KeyVault/KeyVault.bicep
@@ -6,7 +6,7 @@ param name string
 @description('The Tags for the resource')
 param tags object = {}
 @description('The location for the Key Vault - defaults to the resource group location')
-param location string = ''
+param location string = resourceGroup().location
 @allowed([
   'premium'
   'standard'
@@ -55,7 +55,7 @@ param virtualNetworkRules array = []
 
 resource keyvault 'Microsoft.KeyVault/vaults@2021-06-01-preview' = {
   name: name
-  location: location == '' ? resourceGroup().location : location
+  location: location
   tags: tags
   properties: {
     tenantId: subscription().tenantId

--- a/Bicep/LogAnalytics/LogAnalytics.bicep
+++ b/Bicep/LogAnalytics/LogAnalytics.bicep
@@ -3,7 +3,7 @@
 @description('The name of the Log Analytics Workspace - Alphanumerics and hyphens. Start and end with alphanumeric.')
 param name string
 @description('The location for the Log Analystics - defaults to Resource Group Location')
-param location string = ''
+param location string = resourceGroup().location
 @description('The workspace data retention in days. Allowed values are per pricing plan. See pricing tiers documentation for details.')
 param retentionDays int
 @allowed([
@@ -25,7 +25,7 @@ param tags object = {}
 resource loganalytics 'Microsoft.OperationalInsights/workspaces@2021-06-01' = {
   name: name
   tags: tags
-  location: location == '' ? resourceGroup().location : location
+  location: location
   properties: {
     sku: {
       name: skuName

--- a/Bicep/Network/NICs/NetworkInterfacePublicIpNSG.bicep
+++ b/Bicep/Network/NICs/NetworkInterfacePublicIpNSG.bicep
@@ -4,7 +4,7 @@ targetScope = 'resourceGroup'
 @description('The name of the Network Interface')
 param name string
 @description('The location - uses the resource group location by default')
-param location string = ''
+param location string = resourceGroup().location
 @minLength(2)
 @maxLength(64)
 @description('The name of the Virtual Network')
@@ -29,7 +29,7 @@ param networkSecurityGroupResourceGroup string = ''
 
 resource networkInterface 'Microsoft.Network/networkInterfaces@2020-06-01' = if (!empty(publicIpAddressName) && !empty(networkSecurityGroup) ) {
   name: name
-  location: !empty(location) ? location : resourceGroup().location
+  location: location
   properties: {
     ipConfigurations: [
       {

--- a/Bicep/Network/NICs/NetworkInterfaceSimple.bicep
+++ b/Bicep/Network/NICs/NetworkInterfaceSimple.bicep
@@ -4,7 +4,7 @@ targetScope = 'resourceGroup'
 @description('The name of the Network Interface')
 param name string
 @description('The location - uses the resource group location by default')
-param location string = ''
+param location string = resourceGroup().location
 @minLength(2)
 @maxLength(64)
 @description('The name of the Virtual Network')
@@ -20,7 +20,7 @@ param subnetName string
 
 resource networkInterface 'Microsoft.Network/networkInterfaces@2020-06-01' =  {
   name: name
-  location: !empty(location) ? location : resourceGroup().location
+  location: location
   properties: {
     ipConfigurations: [
       {

--- a/Bicep/Network/NSG.bicep
+++ b/Bicep/Network/NSG.bicep
@@ -4,14 +4,14 @@
 param name string
 
 @description('The location - uses the resource group location by default')
-param location string = ''
+param location string = resourceGroup().location
 
 @description('The tags')
 param tags object = {}
 
 resource nsg 'Microsoft.Network/networkSecurityGroups@2021-02-01' = {
   name: name
-  location: !empty(location) ? location : resourceGroup().location
+  location: location
   tags: tags
   properties:{
     securityRules:[]

--- a/Bicep/Network/NetworkInterfacePublicIpNSG.bicep
+++ b/Bicep/Network/NetworkInterfacePublicIpNSG.bicep
@@ -4,7 +4,7 @@ targetScope = 'resourceGroup'
 @description('The name of the Network Interface')
 param name string
 @description('The location - uses the resource group location by default')
-param location string = ''
+param location string = resourceGroup().location
 @minLength(2)
 @maxLength(64)
 @description('The name of the Virtual Network')
@@ -29,7 +29,7 @@ param networkSecurityGroupResourceGroup string = ''
 
 resource networkInterface 'Microsoft.Network/networkInterfaces@2020-06-01' = if (!empty(publicIpAddressName) && !empty(networkSecurityGroup) ) {
   name: name
-  location: !empty(location) ? location : resourceGroup().location
+  location: location
   properties: {
     ipConfigurations: [
       {

--- a/Bicep/Network/NetworkInterfaceSimple.bicep
+++ b/Bicep/Network/NetworkInterfaceSimple.bicep
@@ -4,7 +4,7 @@ targetScope = 'resourceGroup'
 @description('The name of the Network Interface')
 param name string
 @description('The location - uses the resource group location by default')
-param location string = ''
+param location string = resourceGroup().location
 @minLength(2)
 @maxLength(64)
 @description('The name of the Virtual Network')
@@ -20,7 +20,7 @@ param subnetName string
 
 resource networkInterface 'Microsoft.Network/networkInterfaces@2020-06-01' =  {
   name: name
-  location: !empty(location) ? location : resourceGroup().location
+  location: location
   properties: {
     ipConfigurations: [
       {

--- a/Bicep/Network/PrivateEndpointNoDNS.bicep
+++ b/Bicep/Network/PrivateEndpointNoDNS.bicep
@@ -1,7 +1,7 @@
 targetScope = 'resourceGroup'
 
 param name string
-param location string = ''
+param location string = resourceGroup().location
 param tags object = {}
 param subnetid string
 param privateLinkServiceId string
@@ -9,7 +9,7 @@ param groupIds array
 
 resource privateendpoint 'Microsoft.Network/privateEndpoints@2020-07-01' = {
   name: name
-  location: location == '' ? resourceGroup().location : location
+  location: location
   tags: tags
   properties: {
     subnet: {

--- a/Bicep/Network/PublicIPAddress.bicep
+++ b/Bicep/Network/PublicIPAddress.bicep
@@ -6,7 +6,7 @@ targetScope = 'resourceGroup'
 param name string
 
 @description('The location - uses the resource group location by default')
-param location string = ''
+param location string = resourceGroup().location
 
 @description('The tags')
 param tags object = {}
@@ -45,7 +45,7 @@ param publicIPAllocationMethod string = 'Dynamic'
 
 resource publicIP 'Microsoft.Network/publicIPAddresses@2021-02-01' = {
   name: name
-  location: !empty(location) ? location : resourceGroup().location
+  location: location
   tags: tags
   sku: {
     name: skuName

--- a/Bicep/Network/PublicIp/PublicIPAddress.bicep
+++ b/Bicep/Network/PublicIp/PublicIPAddress.bicep
@@ -6,7 +6,7 @@ targetScope = 'resourceGroup'
 param name string
 
 @description('The location - uses the resource group location by default')
-param location string = ''
+param location string = resourceGroup().location
 
 @description('The tags')
 param tags object = {}
@@ -45,7 +45,7 @@ param publicIPAllocationMethod string = 'Dynamic'
 
 resource publicIP 'Microsoft.Network/publicIPAddresses@2021-02-01' = {
   name: name
-  location: !empty(location) ? location : resourceGroup().location
+  location: location
   tags: tags
   sku: {
     name: skuName

--- a/Bicep/Network/VirtualNetwork.bicep
+++ b/Bicep/Network/VirtualNetwork.bicep
@@ -5,7 +5,7 @@ targetScope = 'resourceGroup'
 @description('The name of the Virtual Network')
 param name string
 @description('The location - uses the resource group location by default')
-param location string = ''
+param location string = resourceGroup().location
 @description('A list of address blocks reserved for this virtual network in CIDR notation')
 param addressPrefixes array
 @description('An array of subnet objects - subnetName: Name ; addressPrefix: CIDR notation')
@@ -30,7 +30,7 @@ param dnsServers array = []
 
 resource virtualNetwork 'Microsoft.Network/virtualNetworks@2021-02-01' = {
   name: name
-  location: !empty(location) ? location : resourceGroup().location
+  location: location
   properties: {
     addressSpace: {
       addressPrefixes: [for addressPrefix in addressPrefixes: addressPrefix]

--- a/Bicep/Storage/StorageV2.bicep
+++ b/Bicep/Storage/StorageV2.bicep
@@ -5,7 +5,7 @@ targetScope = 'resourceGroup'
 @description('The name of the storage account -3-24	Lowercase letters and numbers.')
 param name string
 @description('The location - uses the resource group location by default')
-param location string = ''
+param location string = resourceGroup().location
 
 @allowed([
   'Premium_LRS'
@@ -64,7 +64,7 @@ param tags object = {}
 
 resource storage 'Microsoft.Storage/storageAccounts@2021-02-01' = {
   name: name
-  location: !empty(location) ? location : resourceGroup().location
+  location: location
   sku: {
     name: skuName
   }


### PR DESCRIPTION
The bicep linter now flags this pattern as incorrect and the default `resourcegroup().location` resource identifier should be used as the default parameter value

https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/linter-rule-no-loc-expr-outside-params#solution 